### PR TITLE
refactor: Update generic constraint in IQueryHandler interface

### DIFF
--- a/src/2.Core/Base.Core.Contracts/ApplicationServices/Queries/IQueryHandler.cs
+++ b/src/2.Core/Base.Core.Contracts/ApplicationServices/Queries/IQueryHandler.cs
@@ -6,7 +6,7 @@ namespace Base.Core.Contracts.ApplicationServices.Queries;
 /// </summary>
 /// <typeparam name="TQuery">نوع کوئری و پارامتر‌های ورودی را تعیین می‌کند</typeparam>
 /// <typeparam name="TData">نوع داده‌های بازگشتی را تعیین می‌کند</typeparam>
-public interface IQueryHandler<TQuery, TData>
+public interface IQueryHandler<in TQuery, TData>
     where TQuery : class, IQuery<TData>
 {
     Task<QueryResult<TData>> Handle(TQuery request);

--- a/src/2.Core/Base.Core.RequestResponse/Commands/CommandResult.cs
+++ b/src/2.Core/Base.Core.RequestResponse/Commands/CommandResult.cs
@@ -1,6 +1,6 @@
-﻿using Zamin.Core.RequestResponse.Common;
+﻿using Base.Core.RequestResponse.Common;
 
-namespace Zamin.Core.RequestResponse.Commands;
+namespace Base.Core.RequestResponse.Commands;
 /// <summary>
 /// نتیجه انجام هر عملیات به کمک این کلاس بازگشت داده می‌شود.
 /// دلایل استفاده از این الگو و پیاده سازی کاملی از این الگو را در لینک زیر می‌توانید مشاهده کنید


### PR DESCRIPTION
Update the generic constraint in the IQueryHandler interface to use 'in'
keyword for the TQuery type parameter. Also, fix the namespace imports in
CommandResult.cs file to use the correct namespaces.