### PR TITLE
feat: Update package versions in Base.Samples.EndPoints.WebApi.csproj

### DIFF
--- a/samples/3.EndPoints/Base.Samples.EndPoints.WebApi/Base.Samples.EndPoints.WebApi.csproj
+++ b/samples/3.EndPoints/Base.Samples.EndPoints.WebApi/Base.Samples.EndPoints.WebApi.csproj
@@ -17,26 +17,26 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.1" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.1">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.4" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.4">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
 		<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.5.0" />
-		<PackageReference Include="Zamin.Extensions.Caching.InMemory" Version="8.0.0-beta.1" />
-		<PackageReference Include="Zamin.Extensions.Events.PollingPublisher" Version="8.0.0-beta.1" />
-		<PackageReference Include="Zamin.Extensions.Events.PollingPublisher.Dal.Dapper" Version="8.0.0-beta.1" />
+		<PackageReference Include="Zamin.Extensions.Caching.InMemory" Version="8.0.0" />
+		<PackageReference Include="Zamin.Extensions.Events.PollingPublisher" Version="8.0.0" />
+		<PackageReference Include="Zamin.Extensions.Events.PollingPublisher.Dal.Dapper" Version="8.0.0" />
 		<PackageReference Include="Zamin.Extensions.MessageBus.MessageInbox" Version="8.0.1-beta.1" />
-		<PackageReference Include="Zamin.Extensions.MessageBus.MessageInbox.Dal.Dapper" Version="8.0.0-beta.1" />
+		<PackageReference Include="Zamin.Extensions.MessageBus.MessageInbox.Dal.Dapper" Version="8.0.0" />
 		<PackageReference Include="Zamin.Extensions.MessageBus.RabbitMQ" Version="8.0.1-beta.1" />
-		<PackageReference Include="Zamin.Extensions.ObjectMappers.AutoMapper" Version="8.0.0-beta.1" />
-		<PackageReference Include="Zamin.Extensions.Serializers.Microsoft" Version="8.0.0-beta.1" />
-		<PackageReference Include="Zamin.Extensions.Serializers.NewtonSoft" Version="8.0.0-beta.1" />
-		<PackageReference Include="Zamin.Extensions.Translations.Parrot" Version="8.0.0-beta.1" />
-		<PackageReference Include="Zamin.Extensions.UsersManagement" Version="8.0.0-beta.1" />
+		<PackageReference Include="Zamin.Extensions.ObjectMappers.AutoMapper" Version="8.0.0" />
+		<PackageReference Include="Zamin.Extensions.Serializers.Microsoft" Version="8.0.0" />
+		<PackageReference Include="Zamin.Extensions.Serializers.NewtonSoft" Version="8.0.0" />
+		<PackageReference Include="Zamin.Extensions.Translations.Parrot" Version="8.0.0" />
+		<PackageReference Include="Zamin.Extensions.UsersManagement" Version="8.0.0" />
 		<PackageReference Include="Zamin.Utilities.OpenTelemetryRegistration" Version="8.0.0-beta.2" />
-		<PackageReference Include="Zamin.Utilities.SerilogRegistration" Version="8.0.0-beta.1" />
+		<PackageReference Include="Zamin.Utilities.SerilogRegistration" Version="8.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Update several package versions to the latest stable versions for better compatibility and performance:
- Microsoft.AspNetCore.Authentication.JwtBearer to 8.0.4
- Microsoft.EntityFrameworkCore.Tools to 8.0.4
- Zamin Extensions packages to 8.0.0
- Swashbuckle.AspNetCore to 6.5.0

This update ensures that the project uses the most recent dependencies.